### PR TITLE
ux

### DIFF
--- a/components/backup/Encryption.vue
+++ b/components/backup/Encryption.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-12">
-    <v-toolbar color="primary" flat>
+    <v-toolbar flat>
       <v-toolbar-title>{{$t('backup.encryption.title')}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>

--- a/components/backup/Unlock.vue
+++ b/components/backup/Unlock.vue
@@ -18,7 +18,7 @@
 
         <v-card-actions>
           <div class="flex-grow-1"></div>
-          <v-btn color="primary" type="submit" form="login-form" :disabled="!password" @click="onUnlock">{{$t('backup.encryption.actions.unlock')}}</v-btn>
+          <v-btn type="submit" form="login-form" :disabled="!password" @click="onUnlock">{{$t('backup.encryption.actions.unlock')}}</v-btn>
         </v-card-actions>
 
       </v-card>

--- a/components/backup/aws/S3.vue
+++ b/components/backup/aws/S3.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card class="elevation-12">
     <v-toolbar flat>
-      <v-toolbar-title>{{$t('backup.aws.s3.title')}}</v-toolbar-title>
+      <v-toolbar-title v-if="!isEncrypted"><v-alert type="warning" dense dismissible>{{$t('backup.aws.settings.warn.decrypted')}}</v-alert></v-toolbar-title>
       <div class="flex-grow-1"></div>
       <v-btn icon @click="showHelp = true">
         <v-icon>help</v-icon>
@@ -18,11 +18,7 @@
     </v-dialog>
 
     <v-card-text>
-      <v-row v-if="!isEncrypted">
-        <v-col cols="12">
-          <v-alert type="warning" dense dismissible>{{$t('backup.aws.settings.warn.decrypted')}}</v-alert>
-        </v-col>
-      </v-row>
+
       <v-row>
         <v-col cols="12" sm="4">
           <v-text-field

--- a/components/backup/aws/S3.vue
+++ b/components/backup/aws/S3.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-12">
-    <v-toolbar color="primary" flat>
+    <v-toolbar flat>
       <v-toolbar-title>{{$t('backup.aws.s3.title')}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
       <v-btn icon @click="showHelp = true">
@@ -11,7 +11,7 @@
     <v-dialog v-model="showHelp" scrollable>
       <HelpAWSS3>
         <div class="flex-grow-1"></div>
-        <v-btn color="primary" @click="showHelp = false">
+        <v-btn @click="showHelp = false">
           {{$t('common.confirmation.close')}}
         </v-btn>
       </HelpAWSS3>

--- a/components/backup/aws/S3Export.vue
+++ b/components/backup/aws/S3Export.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="onDownloadFile">
+    <v-btn block @click="onDownloadFile">
       <v-icon left>cloud_upload</v-icon>
       {{$t('backup.aws.s3.export.title')}}
     </v-btn>

--- a/components/backup/aws/S3Import.vue
+++ b/components/backup/aws/S3Import.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="onUploadFile" >
+    <v-btn block @click="onUploadFile" >
       <v-icon left>cloud_download</v-icon>
       {{$t('backup.aws.s3.import.title')}}
     </v-btn>

--- a/components/backup/dropbox/Dropbox.vue
+++ b/components/backup/dropbox/Dropbox.vue
@@ -1,10 +1,5 @@
 <template>
   <v-card class="elevation-12">
-    <v-toolbar flat>
-      <v-toolbar-title>{{$t('backup.dropbox.title')}}</v-toolbar-title>
-      <div class="flex-grow-1"></div>
-    </v-toolbar>
-
     <v-card-text>
       <v-row v-if="!isEncrypted">
         <v-col cols="12">
@@ -29,7 +24,7 @@
           </v-col>
         </template>
         <template v-else>
-          <v-col cols="12" >
+          <v-col cols="12" sm="6">
             <v-btn :href="authenticationUrl" block color="primary">
               {{$t('backup.dropbox.login')}}
             </v-btn>

--- a/components/backup/dropbox/Dropbox.vue
+++ b/components/backup/dropbox/Dropbox.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-12">
-    <v-toolbar color="primary" flat>
+    <v-toolbar flat>
       <v-toolbar-title>{{$t('backup.dropbox.title')}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>

--- a/components/backup/dropbox/DropboxExport.vue
+++ b/components/backup/dropbox/DropboxExport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="onDownloadFile">
+    <v-btn block @click="onDownloadFile">
       <v-icon left>cloud_upload</v-icon>
       {{$t('backup.dropbox.export.title')}}
     </v-btn>

--- a/components/backup/dropbox/DropboxImport.vue
+++ b/components/backup/dropbox/DropboxImport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="onUploadFile" >
+    <v-btn block @click="onUploadFile" >
       <v-icon left>cloud_download</v-icon>
       {{$t('backup.dropbox.import.title')}}
     </v-btn>

--- a/components/backup/file/File.vue
+++ b/components/backup/file/File.vue
@@ -1,16 +1,12 @@
 <template>
   <v-card class="elevation-12">
-    <v-toolbar flat>
-      <v-toolbar-title>{{$t('backup.file.title')}}</v-toolbar-title>
-      <div class="flex-grow-1"></div>
-    </v-toolbar>
 
     <v-card-actions>
       <v-row align="center">
-        <v-col md12 lg6>
+        <v-col md="6">
           <FileExport :password.sync="password" />
         </v-col>
-        <v-col md12 lg6>
+        <v-col md="6">
           <FileImport />
         </v-col>
       </v-row>

--- a/components/backup/file/File.vue
+++ b/components/backup/file/File.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-12">
-    <v-toolbar color="primary" flat>
+    <v-toolbar flat>
       <v-toolbar-title>{{$t('backup.file.title')}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>

--- a/components/backup/file/FileExport.vue
+++ b/components/backup/file/FileExport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="onDownloadFile">
+    <v-btn block @click="onDownloadFile">
       <v-icon left>cloud_upload</v-icon>
       {{$t('backup.file.export.title')}}
     </v-btn>

--- a/components/backup/file/FileImport.vue
+++ b/components/backup/file/FileImport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="$refs.fileInput.click()">
+    <v-btn block @click="$refs.fileInput.click()">
       <v-icon left>cloud_download</v-icon>
       {{$t('backup.file.import.title')}}
 

--- a/components/backup/gist/Gist.vue
+++ b/components/backup/gist/Gist.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-12">
-    <v-toolbar color="primary" flat>
+    <v-toolbar flat>
       <v-toolbar-title>{{$t('backup.gist.title')}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
       <v-btn icon @click="showHelp = true">
@@ -11,7 +11,7 @@
     <v-dialog v-model="showHelp" scrollable>
       <HelpGist>
         <div class="flex-grow-1"></div>
-        <v-btn color="primary" @click="showHelp = false">
+        <v-btn @click="showHelp = false">
           {{$t('common.confirmation.close')}}
         </v-btn>
       </HelpGist>

--- a/components/backup/gist/Gist.vue
+++ b/components/backup/gist/Gist.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card class="elevation-12">
     <v-toolbar flat>
-      <v-toolbar-title>{{$t('backup.gist.title')}}</v-toolbar-title>
+      <v-toolbar-title v-if="!isEncrypted"> <v-alert type="warning" dense dismissible>{{$t('backup.gist.settings.warn.decrypted')}}</v-alert></v-toolbar-title>
       <div class="flex-grow-1"></div>
       <v-btn icon @click="showHelp = true">
         <v-icon>help</v-icon>
@@ -18,11 +18,6 @@
     </v-dialog>
 
     <v-card-text>
-      <v-row v-if="!isEncrypted">
-        <v-col cols="12">
-          <v-alert type="warning" dense dismissible>{{$t('backup.gist.settings.warn.decrypted')}}</v-alert>
-        </v-col>
-      </v-row>
       <v-row>
         <v-col cols="12" sm="4">
           <v-text-field

--- a/components/backup/gist/GistExport.vue
+++ b/components/backup/gist/GistExport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="onDownloadFile">
+    <v-btn block @click="onDownloadFile">
       <v-icon left>cloud_upload</v-icon>
       {{$t('backup.gist.export.title')}}
     </v-btn>

--- a/components/backup/gist/GistImport.vue
+++ b/components/backup/gist/GistImport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="onUploadFile" >
+    <v-btn block @click="onUploadFile" >
       <v-icon left>cloud_download</v-icon>
       {{$t('backup.gist.import.title')}}
     </v-btn>

--- a/components/backup/webdav/Webdav.vue
+++ b/components/backup/webdav/Webdav.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-12">
-    <v-toolbar color="primary" flat>
+    <v-toolbar flat>
       <v-toolbar-title>{{$t('backup.webdav.title')}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>

--- a/components/backup/webdav/Webdav.vue
+++ b/components/backup/webdav/Webdav.vue
@@ -1,10 +1,5 @@
 <template>
   <v-card class="elevation-12">
-    <v-toolbar flat>
-      <v-toolbar-title>{{$t('backup.webdav.title')}}</v-toolbar-title>
-      <div class="flex-grow-1"></div>
-    </v-toolbar>
-
     <v-card-text>
       <v-row v-if="!isEncrypted">
         <v-col cols="12">

--- a/components/backup/webdav/WebdavExport.vue
+++ b/components/backup/webdav/WebdavExport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="onDownloadFile">
+    <v-btn block @click="onDownloadFile">
       <v-icon left>cloud_upload</v-icon>
       {{$t('backup.webdav.export.title')}}
     </v-btn>

--- a/components/backup/webdav/WebdavImport.vue
+++ b/components/backup/webdav/WebdavImport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-btn block color="primary" @click="onUploadFile" >
+    <v-btn block @click="onUploadFile" >
       <v-icon left>cloud_download</v-icon>
       {{$t('backup.webdav.import.title')}}
     </v-btn>

--- a/components/help/FirstSteps.vue
+++ b/components/help/FirstSteps.vue
@@ -7,18 +7,28 @@
 
     <v-card-text>
       <vue-markdown :source="$t('note.help.first-steps.preamble', textArgs)" />
-      <div v-for="type of types" :key="type.name">
-        <h3>
-          <v-icon>{{type.icon}}</v-icon>
-          {{$t(`note.${type.name}.title`, textArgs)}}
-        </h3>
-        <vue-markdown :source="$t(`note.${type.name}.help`, textArgs)" />
-      </div>
+
+
+      <v-expansion-panels >
+        <v-expansion-panel>
+          <v-expansion-panel-header><vue-markdown :source="$t('note.help.first-steps.preamble2', textArgs)" /></v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <div v-for="type of types" :key="type.name">
+                <v-icon>{{type.icon}}</v-icon>
+                {{$t(`note.${type.name}.title`, textArgs)}}
+              <vue-markdown :source="$t(`note.${type.name}.help`, textArgs)" />
+            </div>        </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+
+
     </v-card-text>
   </v-card>
 </template>
 
 <script>
+
+  import { mapState, mapGetters } from 'vuex';
   import VueMarkdown from 'vue-markdown'
 
   export default {
@@ -52,6 +62,12 @@
           appName: process.env.appName,
         }
       },
+      ...mapGetters({
+        hasDeletedNotes: 'note/hasDeletedNotes',
+      }),
+      ...mapState({
+        notes: state => state.note.notes,
+      }),
     }
   }
 </script>

--- a/components/note/card/Camera.vue
+++ b/components/note/card/Camera.vue
@@ -39,7 +39,7 @@
     </v-dialog>
 
     <div :class="viewClass">
-      <v-img :src="note.content.image" ></v-img>
+      <v-img :src="note.content.image" v-if="note.content.image != null"></v-img>
 
       <v-card-text v-if="note.content.description">
         <pre>{{note.content.description}}</pre>

--- a/components/note/card/Camera.vue
+++ b/components/note/card/Camera.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-6">
-    <v-toolbar color="primary" flat>
+    <v-toolbar color="primary" flat v-if="note.title !== 'Untitled'">
       <v-toolbar-title>{{note.title}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>
@@ -60,7 +60,7 @@
 
       <div class="flex-grow-1"></div>
 
-      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags">
+      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags" v-if="note.tags.length > 0">
         <v-icon>flag</v-icon>
       </v-btn>
       <v-btn icon @click="fullscreen = true">

--- a/components/note/card/Credentials.vue
+++ b/components/note/card/Credentials.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-6">
-    <v-toolbar color="primary" flat>
+    <v-toolbar color="primary" flat v-if="note.title !== 'Untitled'">
       <v-toolbar-title>{{note.title}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>

--- a/components/note/card/Picture.vue
+++ b/components/note/card/Picture.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-6">
-    <v-toolbar color="primary" flat>
+    <v-toolbar color="primary" flat v-if="note.title !== 'Untitled'">
       <v-toolbar-title>{{note.title}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>
@@ -53,7 +53,7 @@
 
       <div class="flex-grow-1"></div>
 
-      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags">
+      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags" v-if="note.tags.length > 0">
         <v-icon>flag</v-icon>
       </v-btn>
       <v-btn icon @click="fullscreen = true">

--- a/components/note/card/Reminder.vue
+++ b/components/note/card/Reminder.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="elevation-6">
-    <v-toolbar color="primary" flat>
+    <v-toolbar color="primary" flat v-if="note.title !== 'Untitled'">
       <v-toolbar-title>{{note.title}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>
@@ -77,7 +77,7 @@
 
       <div class="flex-grow-1"></div>
 
-      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags">
+      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags" v-if="note.tags.length > 0">
         <v-icon>flag</v-icon>
       </v-btn>
       <v-btn icon @click="fullscreen = true">

--- a/components/note/card/Template.vue
+++ b/components/note/card/Template.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-card class="elevation-6">
-    <v-toolbar color="primary" flat>
+  <v-card class="elevation-6" >
+    <v-toolbar color="primary" flat v-if="note.title !== 'Untitled'">
       <v-toolbar-title>{{note.title}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>
@@ -58,7 +58,7 @@
 
       <div class="flex-grow-1"></div>
 
-      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags">
+      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags" v-if="note.tags.length > 0">
         <v-icon>flag</v-icon>
       </v-btn>
       <v-btn icon @click="fullscreen = true">

--- a/components/note/card/Text.vue
+++ b/components/note/card/Text.vue
@@ -8,7 +8,7 @@
     <v-dialog v-model="fullscreen" fullscreen hide-overlay transition="dialog-bottom-transition">
       <v-card >
         <v-toolbar color="primary" flat >
-          <v-toolbar-title  v-if="note.title !== 'Untitled'">{{note.title}}</v-toolbar-title>
+          <v-toolbar-title >{{note.title}}</v-toolbar-title>
           <div class="flex-grow-1"></div>
           <v-btn icon @click="fullscreen = false">
             <v-icon>fullscreen_exit</v-icon>

--- a/components/note/card/Text.vue
+++ b/components/note/card/Text.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-card class="elevation-6">
-    <v-toolbar color="primary" flat>
+  <v-card class="elevation-6"  style="overflow: hidden">
+    <v-toolbar color="primary" flat v-if="note.title !== 'Untitled'">
       <v-toolbar-title>{{note.title}}</v-toolbar-title>
       <div class="flex-grow-1"></div>
     </v-toolbar>
 
     <v-dialog v-model="fullscreen" fullscreen hide-overlay transition="dialog-bottom-transition">
-      <v-card>
-        <v-toolbar color="primary" flat>
-          <v-toolbar-title>{{note.title}}</v-toolbar-title>
+      <v-card >
+        <v-toolbar color="primary" flat >
+          <v-toolbar-title  v-if="note.title !== 'Untitled'">{{note.title}}</v-toolbar-title>
           <div class="flex-grow-1"></div>
           <v-btn icon @click="fullscreen = false">
             <v-icon>fullscreen_exit</v-icon>
@@ -42,6 +42,8 @@
 
     <div class="text-center pt-2 px-2" v-show="showTags">
       <v-chip v-for="tag of note.tags" :key="tag" class="ma-1">{{tag}}</v-chip>
+      <span v-if="note.tags.length === 0" >{{$t('note.tags.notags')}}</span>
+
     </div>
 
     <v-card-actions>
@@ -57,7 +59,7 @@
 
       <div class="flex-grow-1"></div>
 
-      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags">
+      <v-btn icon :color="showTags ? 'primary' : ''" @click="showTags = !showTags" v-if="note.tags.length > 0">
         <v-icon>flag</v-icon>
       </v-btn>
       <v-btn icon @click="fullscreen = true">

--- a/components/note/form/Text.vue
+++ b/components/note/form/Text.vue
@@ -3,10 +3,10 @@
     <v-container>
       <v-row>
         <v-col cols="12">
-          <v-text-field v-model="note.title" :label="$t('note.title')" :placeholder="$t('note.untitled')"></v-text-field>
-        </v-col>
-        <v-col cols="12">
           <v-textarea v-model="note.content" :label="$t('note.text.content')" :auto-grow="true" :rules="ruleRequired" required autofocus></v-textarea>
+        </v-col>
+        <v-col cols="6">
+          <v-text-field v-model="note.title" :label="$t('note.title')" :placeholder="$t('note.untitled')"></v-text-field>
         </v-col>
         <v-col cols="6">
           <v-switch v-model="note.markdown" :label="$t('note.text.markdown')" color="primary"></v-switch>

--- a/components/settings/Board.vue
+++ b/components/settings/Board.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-card class="elevation-12">
-      <v-toolbar color="primary" flat>
+      <v-toolbar flat>
         <v-toolbar-title>{{$t('settings.boards.title')}}</v-toolbar-title>
         <div class="flex-grow-1"></div>
         <v-btn icon @click="showHelp = true">

--- a/components/settings/Encryption.vue
+++ b/components/settings/Encryption.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-card class="elevation-12">
-      <v-toolbar color="primary" flat>
+      <v-toolbar flat>
         <v-toolbar-title>{{$t('settings.encryption.title')}}</v-toolbar-title>
         <div class="flex-grow-1"></div>
         <v-btn icon @click="showHelp = true">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -18,15 +18,13 @@
           </v-list-item-content>
         </v-list-item>
 
-        <v-divider />
 
         <!-- CUSTOMER generated Links -->
         <v-list-item v-for="link in links" :key="link.route" router exact :to="link.route">
           <v-list-item-action>
-            <v-icon>{{ link.icon }}</v-icon>
           </v-list-item-action>
           <v-list-item-content>
-            <v-list-item-title v-text="link.text" />
+            <v-list-item-title v-text="link.text + ' ('+2+')'" style="text-transform: capitalize;"/>
           </v-list-item-content>
         </v-list-item>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -8,13 +8,13 @@
       fixed
       app
     >
-      <v-list dense>
+      <v-list>
         <v-list-item router exact to="/">
           <v-list-item-action>
             <v-icon>bookmarks</v-icon>
           </v-list-item-action>
           <v-list-item-content>
-            <v-list-item-title v-text="$t('navigation.home')" />
+            <v-list-item-title v-text="$t('navigation.home') + ' (' + notes.length + ')'" />
           </v-list-item-content>
         </v-list-item>
 
@@ -32,17 +32,18 @@
 
         <v-divider />
 
-        <v-list-item router to="/trash/">
+      </v-list>
+        <v-list dense>
+        <v-list-item router to="/trash/" v-if="hasDeletedNotes">
           <v-list-item-action>
-            <v-icon v-if="hasDeletedNotes">delete</v-icon>
-            <v-icon v-else>delete_outline</v-icon>
+            <v-icon>delete</v-icon>
           </v-list-item-action>
           <v-list-item-content>
-            <v-list-item-title v-text="$t('navigation.trash')" />
+            <v-list-item-title v-text="$t('navigation.trash')+ ' (' + deletedNotes.length + ')'" />
           </v-list-item-content>
         </v-list-item>
 
-        <v-list-item router to="/backup/">
+        <v-list-item router to="/backup/" v-if="notes.length > 0 ">
           <v-list-item-action>
             <v-icon>import_export</v-icon>
           </v-list-item-action>
@@ -111,6 +112,8 @@ export default {
     ...mapState({
       boards: state => state.board.boards,
       boardOrder: state => state.board.boardOrder,
+      deletedNotes: state => state.note.deletedNotes,
+      notes: state => state.note.notes,
     }),
     ...mapGetters({
       hasDeletedNotes: 'note/hasDeletedNotes',

--- a/locales/de.json
+++ b/locales/de.json
@@ -71,7 +71,8 @@
     "help": {
       "first-steps": {
         "title": "Willkommen in {appName}",
-        "preamble": "Fügen Sie einfach eine neue Notiz hinzu, indem Sie auf das **Plus-Symbol** in der **unteren rechten Ecke** klicken.\n\nEs gibt verschiedene Arten von Notizen."
+        "preamble": "Fügen Sie einfach eine neue Notiz hinzu, indem Sie auf das **Plus-Symbol** in der **unteren rechten Ecke** klicken.\n\nEs gibt verschiedene Arten von Notizen.",
+        "preamble2": "Learn more about the different types of notes."
       }
     },
     "text": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -66,7 +66,7 @@
     "help": "Help"
   },
   "note": {
-    "title": "Title",
+    "title": "Title (Optional)",
     "untitled": "Untitled",
     "help": {
       "first-steps": {
@@ -78,7 +78,7 @@
     "text": {
       "title": "Text",
       "help": "This is a simple text note. If you copy this note you the shown text is copied. It is also possible to write the content in **Markdown**.",
-      "content": "Content",
+      "content": "Text",
       "markdown": "Markdown"
     },
     "reminder": {
@@ -153,6 +153,7 @@
     },
     "tags": {
       "title": "Tags",
+      "notags": "No tags set",
       "action": {
         "add": {
           "title": "Add tag",

--- a/locales/en.json
+++ b/locales/en.json
@@ -59,8 +59,8 @@
     }
   },
   "navigation": {
-    "home": "All",
-    "trash": "Trash",
+    "home": "Dev Notes",
+    "trash": "Deleted Notes",
     "settings": "Settings",
     "backup": "Backup",
     "help": "Help"
@@ -71,7 +71,8 @@
     "help": {
       "first-steps": {
         "title": "Welcome to {appName}",
-        "preamble": "Just add a new note by clicking on the **plus icon** in the **lower right corner**.\n\nThere are different types of notes."
+        "preamble": "Add a note by clicking on the **plus icon** in the **lower right corner**",
+        "preamble2": "Different types of notes."
       }
     },
     "text": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -484,7 +484,7 @@
       "title": "Language"
     },
     "others": {
-      "title": "Others"
+      "title": "General Settings"
     }
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -103,31 +103,28 @@ export default {
   */
   vuetify: {
     customVariables: ['~/assets/variables.scss'],
-    theme: {
-      themes: {
-        dark: {
-          primary: '#74B392',
-          accent: '#eaff00',
-          secondary: '#FFE7A2',
-          info: '#40f934',
-          warning: '#b8b11e',
-          error: '#FF6363',
-          success: '#74B392',
-        },
-        light: {
-          primary: '#74B392',
-          accent: '#eaff00',
-          secondary: '#FFE7A2',
-          info: '#40f934',
-          warning: '#FFE7A2',
-          error: '#FF6363',
-          success: '#74B392',
-
-          header: '#FFE7A2',
-          footer: '',
-          navigation: colors.grey.lighten3,
+      theme: {
+        dark: true,
+        themes: {
+          dark: {
+            primary: '#16282C',
+            accent: '#FF4081',
+            secondary: '#FFE18D',
+            success: '#4CAF50',
+            info: '#2196F3',
+            warning: '#FB8C00',
+            error: '#FF5252'
+          },
+          light: {
+            primary: '#1976D2',
+            accent: '#e91e63',
+            secondary: '#30b1dc',
+            success: '#4CAF50',
+            info: '#2196F3',
+            warning: '#FB8C00',
+            error: '#FF5252'
+          }
         }
-      }
     }
   },
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -103,7 +103,7 @@ export default {
   */
   vuetify: {
     customVariables: ['~/assets/variables.scss'],
-      theme: {
+     /* theme: {
         dark: true,
         themes: {
           dark: {
@@ -125,7 +125,7 @@ export default {
             error: '#FF5252'
           }
         }
-    }
+    }*/
   },
   /*
   ** Build configuration

--- a/pages/backup/index.vue
+++ b/pages/backup/index.vue
@@ -10,39 +10,56 @@
       </v-dialog>
 
       <!-- FILE  -->
+
       <v-row align="center">
         <v-col cols="12">
-          <BackupFile :password.sync="password" />
+          <v-expansion-panels v-model="panel" accordion>
+
+            <v-expansion-panel>
+              <v-expansion-panel-header>{{$t('backup.file.title')}}</v-expansion-panel-header>
+              <v-expansion-panel-content>
+                <BackupFile :password.sync="password" />
+              </v-expansion-panel-content>
+            </v-expansion-panel>
+
+            <!-- WebDAV  -->
+            <v-expansion-panel>
+              <v-expansion-panel-header>{{$t('backup.webdav.title')}}</v-expansion-panel-header>
+              <v-expansion-panel-content>
+                <BackupWebdav :password.sync="password" />
+              </v-expansion-panel-content>
+            </v-expansion-panel>
+
+          <!-- Gist  -->
+          <v-expansion-panel>
+            <v-expansion-panel-header>{{$t('backup.gist.title')}}</v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <BackupGist :password.sync="password" />
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+
+          <!-- AWS S3 -->
+          <v-expansion-panel>
+            <v-expansion-panel-header>{{$t('backup.aws.s3.title')}}</v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <BackupS3 :password.sync="password" />
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+
+            <!-- Dropbox -->
+            <v-expansion-panel>
+              <v-expansion-panel-header>{{$t('backup.dropbox.title')}}</v-expansion-panel-header>
+              <v-expansion-panel-content>
+                <BackupDropbox :password.sync="password" />
+              </v-expansion-panel-content>
+            </v-expansion-panel>
+
+
+          </v-expansion-panels>
+
         </v-col>
       </v-row>
 
-      <!-- WebDAV  -->
-      <v-row align="center">
-        <v-col cols="12">
-          <BackupWebdav :password.sync="password" />
-        </v-col>
-      </v-row>
-
-      <!-- Gist  -->
-      <v-row align="center">
-        <v-col cols="12">
-          <BackupGist :password.sync="password" />
-        </v-col>
-      </v-row>
-
-      <!-- AWS S3 -->
-      <v-row align="center">
-        <v-col cols="12">
-          <BackupS3 :password.sync="password" />
-        </v-col>
-      </v-row>
-
-      <!-- Dropbox -->
-      <v-row align="center">
-        <v-col cols="12">
-          <BackupDropbox :password.sync="password" />
-        </v-col>
-      </v-row>
     </v-layout>
 
     <v-footer app class="pa-0">
@@ -78,7 +95,8 @@
           encryption: {
             open: false
           }
-        }
+        },
+        panel: 0
       }
     },
     computed: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -75,12 +75,11 @@
 
         <v-footer app padless>
             <v-toolbar dense color="footer" v-if="existNotes">
-                <v-toolbar-items>
-                    <NoteOrderConfig/>
-                </v-toolbar-items>
                 <div class="flex-grow-1"></div>
 
                 <v-toolbar-items>
+                    <NoteOrderConfig/>
+
                     <v-btn @click="showTags = !showTags" v-if="availableTags.length > 0">
                         <v-icon :color="showTags ? 'primary' : ''">flag</v-icon>
                     </v-btn>
@@ -103,9 +102,11 @@
                             </v-list-item>
                         </v-list>
                     </v-menu>
+
+
                     <v-menu offset-y top>
                         <template v-slot:activator="{ on }">
-                            <v-btn v-on="on">
+                            <v-btn v-on="on" @click="onNewNote({id: 'text'})">
                                 <v-icon>add_circle</v-icon>
                             </v-btn>
                         </template>
@@ -128,7 +129,7 @@
 
                 <v-menu offset-y top>
                   <template v-slot:activator="{ on }">
-                    <v-btn v-on="on">
+                    <v-btn v-on="on" @click="onNewNote({id: 'text'})">
                       <v-icon>add_circle</v-icon>
                     </v-btn>
                   </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,339 +1,362 @@
 <template>
-  <v-container fluid>
-    <v-row justify="center" v-if="!existNotes">
-      <v-col>
-        <HelpFirstSteps />
-      </v-col>
-    </v-row>
+    <v-container fluid>
+        <v-row justify="center" v-if="!existNotes">
+            <v-col>
+                <HelpFirstSteps/>
+            </v-col>
+        </v-row>
 
-    <v-row align="center">
-      <v-col cols="12" sm="6" md="3" v-for="note of filteredNotes" :key="note.id">
+        <v-row align="center">
+            <v-col cols="12" sm="6" md="3" v-for="note of filteredNotes" :key="note.id">
 
-        <NoteCardText v-if="note.type === 'text'" :note="note"
-                      :show-tags="showTags"
-                      @onCopy="onCopyNote"
-                      @onEdit="onEditRequest(note)"
-                      @onDelete="onDeleteRequest(note.id)" />
-        <NoteCardReminder v-if="note.type === 'reminder'" :note="note"
-                      :show-tags="showTags"
-                      @onCopy="onCopyNote"
-                      @onEdit="onEditRequest(note)"
-                      @onDelete="onDeleteRequest(note.id)" />
-        <NoteCardCredentials v-if="note.type === 'credentials'" :note="note"
-                      :show-tags="showTags"
-                      @onCopy="onCopyNote"
-                      @onEdit="onEditRequest(note)"
-                      @onDelete="onDeleteRequest(note.id)" />
-        <NoteCardPicture v-if="note.type === 'picture'" :note="note"
-                         :show-tags="showTags"
-                         @onCopy="onCopyNote"
-                         @onEdit="onEditRequest(note)"
-                         @onDelete="onDeleteRequest(note.id)" />
-        <NoteCardCamera v-if="note.type === 'camera'" :note="note"
-                         :show-tags="showTags"
-                         @onCopy="onCopyNote"
-                         @onEdit="onEditRequest(note)"
-                         @onDelete="onDeleteRequest(note.id)" />
-        <NoteCardTemplate v-if="note.type === 'template'" :note="note"
-                          :show-tags="showTags"
-                          @onCopy="onCopyNote"
-                          @onEdit="onEditRequest(note)"
-                          @onDelete="onDeleteRequest(note.id)" />
+                <NoteCardText v-if="note.type === 'text'" :note="note"
+                              :show-tags="showTags"
+                              @onCopy="onCopyNote"
+                              @onEdit="onEditRequest(note)"
+                              @onDelete="onDeleteRequest(note.id)"/>
+                <NoteCardReminder v-if="note.type === 'reminder'" :note="note"
+                                  :show-tags="showTags"
+                                  @onCopy="onCopyNote"
+                                  @onEdit="onEditRequest(note)"
+                                  @onDelete="onDeleteRequest(note.id)"/>
+                <NoteCardCredentials v-if="note.type === 'credentials'" :note="note"
+                                     :show-tags="showTags"
+                                     @onCopy="onCopyNote"
+                                     @onEdit="onEditRequest(note)"
+                                     @onDelete="onDeleteRequest(note.id)"/>
+                <NoteCardPicture v-if="note.type === 'picture'" :note="note"
+                                 :show-tags="showTags"
+                                 @onCopy="onCopyNote"
+                                 @onEdit="onEditRequest(note)"
+                                 @onDelete="onDeleteRequest(note.id)"/>
+                <NoteCardCamera v-if="note.type === 'camera'" :note="note"
+                                :show-tags="showTags"
+                                @onCopy="onCopyNote"
+                                @onEdit="onEditRequest(note)"
+                                @onDelete="onDeleteRequest(note.id)"/>
+                <NoteCardTemplate v-if="note.type === 'template'" :note="note"
+                                  :show-tags="showTags"
+                                  @onCopy="onCopyNote"
+                                  @onEdit="onEditRequest(note)"
+                                  @onDelete="onDeleteRequest(note.id)"/>
 
-      </v-col>
-    </v-row>
+            </v-col>
+        </v-row>
 
-    <v-dialog v-model="dialog.delete.open" max-width="290">
-      <v-card>
-        <v-card-title class="headline">{{$t('common.confirmation.title')}}</v-card-title>
-        <v-card-text>{{$t('note.delete.confirmation')}}</v-card-text>
+        <v-dialog v-model="dialog.delete.open" max-width="290">
+            <v-card>
+                <v-card-title class="headline">{{$t('common.confirmation.title')}}</v-card-title>
+                <v-card-text>{{$t('note.delete.confirmation')}}</v-card-text>
 
-        <v-card-actions>
-          <div class="flex-grow-1"></div>
-          <v-btn color="error" @click="onDeleteNote()">
-            {{$t('common.confirmation.agree')}}
-          </v-btn>
-          <v-btn color="primary" @click="dialog.delete.open = false">
-            {{$t('common.confirmation.disagree')}}
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+                <v-card-actions>
+                    <div class="flex-grow-1"></div>
+                    <v-btn color="error" @click="onDeleteNote()">
+                        {{$t('common.confirmation.agree')}}
+                    </v-btn>
+                    <v-btn color="primary" @click="dialog.delete.open = false">
+                        {{$t('common.confirmation.disagree')}}
+                    </v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
 
-    <v-snackbar v-model="snackbar.copied" color="success" class="text-center" :timeout="1000">
-      {{$t('note.copy.successful')}}
-      <v-btn text @click="snackbar.copied = false" >
-        <v-icon>close</v-icon>
-      </v-btn>
-    </v-snackbar>
-    <v-snackbar v-model="snackbar.trash" color="success" class="text-center" :timeout="1000">
-      {{$t('note.delete.trash')}}
-      <v-btn text @click="snackbar.trash = false" >
-        <v-icon>close</v-icon>
-      </v-btn>
-    </v-snackbar>
+        <v-snackbar v-model="snackbar.copied" color="success" class="text-center" :timeout="1000">
+            {{$t('note.copy.successful')}}
+            <v-btn text @click="snackbar.copied = false">
+                <v-icon>close</v-icon>
+            </v-btn>
+        </v-snackbar>
+        <v-snackbar v-model="snackbar.trash" color="success" class="text-center" :timeout="1000">
+            {{$t('note.delete.trash')}}
+            <v-btn text @click="snackbar.trash = false">
+                <v-icon>close</v-icon>
+            </v-btn>
+        </v-snackbar>
 
-    <v-footer app class="pa-0">
-      <v-toolbar dense color="footer">
-        <v-toolbar-items>
-          <NoteOrderConfig />
-        </v-toolbar-items>
-        <div class="flex-grow-1"></div>
+        <v-footer app padless>
+            <v-toolbar dense color="footer" v-if="existNotes">
+                <v-toolbar-items>
+                    <NoteOrderConfig/>
+                </v-toolbar-items>
+                <div class="flex-grow-1"></div>
 
-        <v-toolbar-items>
-          <v-btn @click="showTags = !showTags">
-            <v-icon :color="showTags ? 'primary' : ''">flag</v-icon>
-          </v-btn>
+                <v-toolbar-items>
+                    <v-btn @click="showTags = !showTags">
+                        <v-icon :color="showTags ? 'primary' : ''">flag</v-icon>
+                    </v-btn>
 
-          <v-menu offset-y top max-height="50%" :close-on-content-click="false">
-            <template v-slot:activator="{ on }">
-              <v-btn v-on="on" :color="filter.active ? 'primary' : ''">
-                <v-icon>search</v-icon>
-              </v-btn>
-            </template>
-            <v-list v-if="availableTags && availableTags.length > 0">
-              <v-list-item v-for="tag in availableTags" :key="tag">
-                <v-btn block class="text-none" @click="onFilterTagChange(tag)">
-                  <v-icon v-if="filter.tags[tag] === true" color="green">check_circle</v-icon>
-                  <v-icon v-if="filter.tags[tag] === false" color="red">remove_circle</v-icon>
-                  <v-icon v-if="filter.tags[tag] === null">filter_list</v-icon>
-                  <span class="flex-grow-1"></span>
-                  {{tag}}
-                </v-btn>
-              </v-list-item>
-            </v-list>
-          </v-menu>
-          <v-menu offset-y top>
-            <template v-slot:activator="{ on }">
-              <v-btn v-on="on">
-                <v-icon>add_circle</v-icon>
-              </v-btn>
-            </template>
-            <v-list>
-              <v-list-item v-for="type in note.types" :key="type.id">
-                <v-btn block @click="onNewNote(type)">
-                  <v-icon left>{{type.icon}}</v-icon>
-                  {{$t(`note.${type.id}.title`)}}
-                </v-btn>
-              </v-list-item>
-            </v-list>
-          </v-menu>
-        </v-toolbar-items>
-      </v-toolbar>
-    </v-footer>
-  </v-container>
+                    <v-menu offset-y top max-height="50%" :close-on-content-click="false">
+                        <template v-slot:activator="{ on }">
+                            <v-btn v-on="on" :color="filter.active ? 'primary' : ''">
+                                <v-icon>search</v-icon>
+                            </v-btn>
+                        </template>
+                        <v-list v-if="availableTags && availableTags.length > 0">
+                            <v-list-item v-for="tag in availableTags" :key="tag">
+                                <v-btn block class="text-none" @click="onFilterTagChange(tag)">
+                                    <v-icon v-if="filter.tags[tag] === true" color="green">check_circle</v-icon>
+                                    <v-icon v-if="filter.tags[tag] === false" color="red">remove_circle</v-icon>
+                                    <v-icon v-if="filter.tags[tag] === null">filter_list</v-icon>
+                                    <span class="flex-grow-1"></span>
+                                    {{tag}}
+                                </v-btn>
+                            </v-list-item>
+                        </v-list>
+                    </v-menu>
+                    <v-menu offset-y top>
+                        <template v-slot:activator="{ on }">
+                            <v-btn v-on="on">
+                                <v-icon>add_circle</v-icon>
+                            </v-btn>
+                        </template>
+                        <v-list>
+                            <v-list-item v-for="type in note.types" :key="type.id">
+                                <v-btn block @click="onNewNote(type)">
+                                    <v-icon left>{{type.icon}}</v-icon>
+                                    {{$t(`note.${type.id}.title`)}}
+                                </v-btn>
+                            </v-list-item>
+                        </v-list>
+                    </v-menu>
+                </v-toolbar-items>
+            </v-toolbar>
+            <v-toolbar dense color="footer" v-else>
+
+              <v-spacer></v-spacer>
+
+              <v-toolbar-items >
+
+                <v-menu offset-y top>
+                  <template v-slot:activator="{ on }">
+                    <v-btn v-on="on">
+                      <v-icon>add_circle</v-icon>
+                    </v-btn>
+                  </template>
+                  <v-list>
+                    <v-list-item v-for="type in note.types" :key="type.id">
+                      <v-btn block @click="onNewNote(type)" right>
+                        <v-icon left>{{type.icon}}</v-icon>
+                        {{$t(`note.${type.id}.title`)}}
+                      </v-btn>
+                    </v-list-item>
+                  </v-list>
+                </v-menu>
+              </v-toolbar-items>
+            </v-toolbar>
+        </v-footer>
+    </v-container>
 </template>
 
 <script>
-import { mapGetters, mapState, mapMutations } from 'vuex';
-import Vue from 'vue'
-import copy from 'copy-to-clipboard';
+    import {mapGetters, mapState, mapMutations} from 'vuex';
+    import Vue from 'vue'
+    import copy from 'copy-to-clipboard';
 
-import { readBoardQuery } from '../common/boardQuery'
-import NoteCardText from "../components/note/card/Text";
-import NoteCardPicture from "../components/note/card/Picture";
-import NoteFormText from "../components/note/form/Text";
-import NoteFormPicture from "../components/note/form/Picture";
-import NoteFormTemplate from "../components/note/form/Template";
-import NoteCardTemplate from "../components/note/card/Template";
-import HelpFirstSteps from "../components/help/FirstSteps";
-import NoteOrderConfig from "../components/note/OrderConfig";
-import NoteFormCredentials from "../components/note/form/Credentials";
-import NoteCardCredentials from "../components/note/card/Credentials";
-import NoteFormCamera from "../components/note/form/Camera";
-import NoteCardCamera from "../components/note/card/Camera";
-import NoteFormReminder from "../components/note/form/Reminder";
-import NoteCardReminder from "../components/note/card/Reminder";
+    import {readBoardQuery} from '../common/boardQuery'
+    import NoteCardText from "../components/note/card/Text";
+    import NoteCardPicture from "../components/note/card/Picture";
+    import NoteFormText from "../components/note/form/Text";
+    import NoteFormPicture from "../components/note/form/Picture";
+    import NoteFormTemplate from "../components/note/form/Template";
+    import NoteCardTemplate from "../components/note/card/Template";
+    import HelpFirstSteps from "../components/help/FirstSteps";
+    import NoteOrderConfig from "../components/note/OrderConfig";
+    import NoteFormCredentials from "../components/note/form/Credentials";
+    import NoteCardCredentials from "../components/note/card/Credentials";
+    import NoteFormCamera from "../components/note/form/Camera";
+    import NoteCardCamera from "../components/note/card/Camera";
+    import NoteFormReminder from "../components/note/form/Reminder";
+    import NoteCardReminder from "../components/note/card/Reminder";
 
-export default {
-  components: {
-    NoteCardReminder,
-    NoteFormReminder,
-    NoteOrderConfig,
-    HelpFirstSteps,
-    NoteCardTemplate,
-    NoteFormTemplate,
-    NoteCardText,
-    NoteFormText,
-    NoteCardPicture,
-    NoteFormPicture,
-    NoteCardCredentials,
-    NoteFormCredentials,
-    NoteCardCamera,
-    NoteFormCamera
-  },
-  data(){
-    return {
-      dialog: {
-        delete: {
-          open: false,
-          noteId: null
-        }
-      },
+    export default {
+        components: {
+            NoteCardReminder,
+            NoteFormReminder,
+            NoteOrderConfig,
+            HelpFirstSteps,
+            NoteCardTemplate,
+            NoteFormTemplate,
+            NoteCardText,
+            NoteFormText,
+            NoteCardPicture,
+            NoteFormPicture,
+            NoteCardCredentials,
+            NoteFormCredentials,
+            NoteCardCamera,
+            NoteFormCamera
+        },
+        data() {
+            return {
+                dialog: {
+                    delete: {
+                        open: false,
+                        noteId: null
+                    }
+                },
 
-      showTags: false,
+                showTags: false,
 
-      filter: {
-        active: false,
-        tags: {},
-      },
+                filter: {
+                    active: false,
+                    tags: {},
+                },
 
-      snackbar: {
-        copied: false,
-        trash: false
-      },
+                snackbar: {
+                    copied: false,
+                    trash: false
+                },
 
-      note: {
-        data: {},
-        types: [
-          { id: 'template', icon: 'ballot' },
-          { id: 'credentials', icon: 'fingerprint' },
-          { id: 'picture', icon: 'photo' },
-          { id: 'camera', icon: 'camera' },
-          { id: 'reminder', icon: 'alarm' },
-          { id: 'text', icon: 'notes' },
-        ]
-      }
+                note: {
+                    data: {},
+                    types: [
+                        {id: 'template', icon: 'ballot'},
+                        {id: 'credentials', icon: 'fingerprint'},
+                        {id: 'picture', icon: 'photo'},
+                        {id: 'camera', icon: 'camera'},
+                        {id: 'reminder', icon: 'alarm'},
+                        {id: 'text', icon: 'notes'},
+                    ]
+                }
+            }
+        },
+        computed: {
+            ...mapGetters({
+                noteTags: 'note/getAvailableTags',
+                boardTags: 'board/getAvailableTags'
+            }),
+            ...mapState({
+                notes: state => state.note.notes,
+                noteOrder: state => state.note.noteOrder,
+                noteDeleteHard: state => state.settings.notes.deleteHard
+            }),
+            availableTags() {
+                let tags = {}
+                for (let tag of this.noteTags) tags[tag] = true
+                for (let tag of this.boardTags) tags[tag] = true
+
+                return Object.keys(tags).sort()
+            },
+            filteredNotes() {
+                let noteMap = {}
+                for (let note of this.notes) {
+                    noteMap[note.id] = note
+                }
+
+                if (!this.availableTags || this.availableTags.length === 0) {
+                    return this.noteOrder.map(nId => noteMap[nId])
+                }
+
+                let blacklist = {}
+                let whitelist = {}
+
+                for (let tagName of Object.keys(this.filter.tags)) {
+                    let tagValue = this.filter.tags[tagName]
+
+                    if (tagValue === true) whitelist[tagName] = true
+                    else if (tagValue === false) blacklist[tagName] = true
+                }
+
+                return this.noteOrder.map(nId => noteMap[nId]).filter(note => {
+                    let tagsMap = {}
+                    for (let tag of note.tags) tagsMap[tag] = true
+
+                    for (let blacklistedTag of Object.keys(blacklist)) {
+                        if (tagsMap.hasOwnProperty(blacklistedTag)) {
+                            //this tag is blacklisted -> not should be filtered out!
+                            return false
+                        }
+                    }
+
+                    for (let whitelistedTag of Object.keys(whitelist)) {
+                        if (!tagsMap.hasOwnProperty(whitelistedTag)) {
+                            //this tag is not included in note -> this note should be filtered out!
+                            return false
+                        }
+                    }
+
+                    return true
+                })
+            },
+            existNotes() {
+                return this.notes.length > 0
+            },
+        },
+        methods: {
+            ...mapMutations({
+                deleteNote: 'note/deleteNote',
+                deleteNoteSoft: 'note/deleteNoteSoft',
+            }),
+            onNewNote(type) {
+                this.$router.push("/notes/new/" + type.id)
+            },
+            onEditRequest(note) {
+                this.$router.push("/notes/edit/" + note.id)
+            },
+            onDeleteRequest(id) {
+                if (this.noteDeleteHard) {
+                    this.dialog.delete.open = true
+                    this.dialog.delete.noteId = id
+                } else {
+                    this.deleteNoteSoft(id)
+                    this.snackbar.trash = true
+                }
+            },
+            onDeleteNote() {
+                this.deleteNote(this.dialog.delete.noteId)
+                this.dialog.delete.open = false
+                this.dialog.delete.noteId = null
+            },
+            onCopyNote(content) {
+                this.snackbar.copied = false
+                copy(content)
+                this.snackbar.copied = true
+            },
+            onFilterTagChange(tag) {
+                if (this.filter.tags[tag] === true) this.filter.tags[tag] = false
+                else if (this.filter.tags[tag] === false) this.filter.tags[tag] = null
+                else if (this.filter.tags[tag] === null) this.filter.tags[tag] = true
+            },
+            applyTags(tags) {
+                //add missing
+                for (let tag of tags) {
+                    if (!this.filter.tags.hasOwnProperty(tag)) {
+                        Vue.set(this.filter.tags, tag, null)
+                    }
+                }
+            },
+            applyQueryTags() {
+                this.filter.tags = {}
+                this.applyTags(this.availableTags)
+
+                let boardInfo = readBoardQuery(this.$route.query)
+                for (let tagName of Object.keys(boardInfo.tags)) {
+                    this.filter.tags[tagName] = boardInfo.tags[tagName]
+                }
+            }
+        },
+        watch: {
+            availableTags(tags) {
+                this.applyTags(tags)
+            },
+            '$route.query'() {
+                this.applyQueryTags()
+            },
+            'filter.tags': {
+                deep: true,
+                handler(tags) {
+                    this.filter.active = false
+
+                    for (let tagValue of Object.values(tags)) {
+                        if (tagValue !== null) {
+                            this.filter.active = true
+                            break
+                        }
+                    }
+                }
+            }
+        },
+        mounted() {
+            this.applyQueryTags()
+        },
     }
-  },
-  computed: {
-    ...mapGetters({
-      noteTags: 'note/getAvailableTags',
-      boardTags: 'board/getAvailableTags'
-    }),
-    ...mapState({
-      notes: state => state.note.notes,
-      noteOrder: state => state.note.noteOrder,
-      noteDeleteHard: state => state.settings.notes.deleteHard
-    }),
-    availableTags() {
-      let tags = {}
-      for(let tag of this.noteTags) tags[tag] = true
-      for(let tag of this.boardTags) tags[tag] = true
-
-      return Object.keys(tags).sort()
-    },
-    filteredNotes(){
-      let noteMap = {}
-      for(let note of this.notes) {
-        noteMap[note.id] = note
-      }
-
-      if(!this.availableTags || this.availableTags.length === 0){
-        return this.noteOrder.map(nId => noteMap[nId])
-      }
-
-      let blacklist = {}
-      let whitelist = {}
-
-      for(let tagName of Object.keys(this.filter.tags)) {
-        let tagValue = this.filter.tags[tagName]
-
-        if(tagValue === true) whitelist[tagName] = true
-        else if(tagValue === false) blacklist[tagName] = true
-      }
-
-      return this.noteOrder.map(nId => noteMap[nId]).filter(note => {
-        let tagsMap = {}
-        for(let tag of note.tags) tagsMap[tag] = true
-
-        for(let blacklistedTag of Object.keys(blacklist)) {
-          if(tagsMap.hasOwnProperty(blacklistedTag)) {
-            //this tag is blacklisted -> not should be filtered out!
-            return false
-          }
-        }
-
-        for(let whitelistedTag of Object.keys(whitelist)) {
-          if(!tagsMap.hasOwnProperty(whitelistedTag)) {
-            //this tag is not included in note -> this note should be filtered out!
-            return false
-          }
-        }
-
-        return true
-      })
-    },
-    existNotes() {
-      return this.notes.length > 0
-    },
-  },
-  methods: {
-    ...mapMutations({
-      deleteNote: 'note/deleteNote',
-      deleteNoteSoft: 'note/deleteNoteSoft',
-    }),
-    onNewNote(type) {
-      this.$router.push("/notes/new/" + type.id)
-    },
-    onEditRequest(note) {
-      this.$router.push("/notes/edit/" + note.id)
-    },
-    onDeleteRequest(id) {
-      if(this.noteDeleteHard) {
-        this.dialog.delete.open = true
-        this.dialog.delete.noteId = id
-      } else {
-        this.deleteNoteSoft(id)
-        this.snackbar.trash = true
-      }
-    },
-    onDeleteNote() {
-      this.deleteNote(this.dialog.delete.noteId)
-      this.dialog.delete.open = false
-      this.dialog.delete.noteId = null
-    },
-    onCopyNote(content) {
-      this.snackbar.copied = false
-      copy(content)
-      this.snackbar.copied = true
-    },
-    onFilterTagChange(tag){
-      if(this.filter.tags[tag] === true) this.filter.tags[tag] = false
-      else if(this.filter.tags[tag] === false) this.filter.tags[tag] = null
-      else if(this.filter.tags[tag] === null) this.filter.tags[tag] = true
-    },
-    applyTags(tags){
-      //add missing
-      for(let tag of tags) {
-        if(!this.filter.tags.hasOwnProperty(tag)){
-          Vue.set(this.filter.tags, tag, null)
-        }
-      }
-    },
-    applyQueryTags(){
-      this.filter.tags = {}
-      this.applyTags(this.availableTags)
-
-      let boardInfo = readBoardQuery(this.$route.query)
-      for(let tagName of Object.keys(boardInfo.tags)) {
-        this.filter.tags[tagName] = boardInfo.tags[tagName]
-      }
-    }
-  },
-  watch: {
-    availableTags(tags) {
-      this.applyTags(tags)
-    },
-    '$route.query'() {
-      this.applyQueryTags()
-    },
-    'filter.tags': {
-      deep: true,
-      handler(tags){
-        this.filter.active = false
-
-        for(let tagValue of Object.values(tags)) {
-          if(tagValue !== null){
-            this.filter.active = true
-            break
-          }
-        }
-      }
-    }
-  },
-  mounted() {
-    this.applyQueryTags()
-  },
-}
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -81,7 +81,7 @@
                 <div class="flex-grow-1"></div>
 
                 <v-toolbar-items>
-                    <v-btn @click="showTags = !showTags">
+                    <v-btn @click="showTags = !showTags" v-if="availableTags.length > 0">
                         <v-icon :color="showTags ? 'primary' : ''">flag</v-icon>
                     </v-btn>
 

--- a/pages/notes/new/_type.vue
+++ b/pages/notes/new/_type.vue
@@ -4,6 +4,23 @@
     <v-card>
 
       <v-card-text>
+        <v-select
+                @change="onNewNote"
+                :items="note.types"
+                solo
+        >
+          <template v-slot:item="{item}">
+            <v-icon>{{item.icon}}</v-icon> {{$t(`note.${item.id}.title`)}}
+          </template>
+          <template v-slot:label>
+            <v-icon>{{note.types[0].icon}}</v-icon>
+            {{note.types[noteTypeIndex].text}}{{$t(`note.${note.types[noteTypeIndex].id}.title`)}}
+          </template>
+          <template v-slot:selection="{item}">
+            <v-icon>{{item.icon}}</v-icon> {{$t(`note.${item.id}.title`)}}
+          </template>
+        </v-select>
+
         <NoteFormText form-id="note-new-form" v-if="noteType === 'text'" @onSubmit="onSaveNewNote" ></NoteFormText>
         <NoteFormReminder form-id="note-new-form" v-if="noteType === 'reminder'" @onSubmit="onSaveNewNote" ></NoteFormReminder>
         <NoteFormPicture form-id="note-new-form" v-if="noteType === 'picture'" @onSubmit="onSaveNewNote" ></NoteFormPicture>
@@ -58,17 +75,36 @@ export default {
     NoteFormCamera
   },
   data(){
-    return {}
+    return {
+      note: {
+        data: {},
+        types: [
+          {id: 'template', icon: 'ballot'},
+          {id: 'credentials', icon: 'fingerprint'},
+          {id: 'picture', icon: 'photo'},
+          {id: 'camera', icon: 'camera'},
+          {id: 'reminder', icon: 'alarm'},
+          {id: 'text', icon: 'notes'},
+        ]
+      }
+    }
   },
   computed: {
     noteType(){
       return this.$route.params.type
     },
+    noteTypeIndex(){
+      var self = this
+      return this.note.types.findIndex(t => t.id === self.noteType)
+    }
   },
   methods: {
     ...mapMutations({
       addNote: 'note/addNote',
     }),
+    onNewNote(type) {
+      this.$router.push("/notes/new/" + type.id)
+    },
     onAbort(){
       this.$router.back()
     },

--- a/pages/notes/new/_type.vue
+++ b/pages/notes/new/_type.vue
@@ -2,9 +2,7 @@
   <v-container fluid>
 
     <v-card>
-      <v-card-title>
-        <span class="headline">{{$t(`note.${noteType}.title`)}}</span>
-      </v-card-title>
+
       <v-card-text>
         <NoteFormText form-id="note-new-form" v-if="noteType === 'text'" @onSubmit="onSaveNewNote" ></NoteFormText>
         <NoteFormReminder form-id="note-new-form" v-if="noteType === 'reminder'" @onSubmit="onSaveNewNote" ></NoteFormReminder>

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -16,25 +16,26 @@
             </v-toolbar>
             <v-card-text class="pb-0">
               <v-row>
-                <v-col cols="4" >
-                  <SettingsNote />
-                </v-col>
-                <v-col cols="4" sm="4">
-                  <SettingsTheme />
-                </v-col>
-                <v-col cols="4" sm="4">
+                <v-col cols="12" sm="6">
                   <SettingsLanguage />
                 </v-col>
-                <v-col cols="4" >
+                <v-col cols="12" sm="6" >
                   <SettingsDateTime />
                 </v-col>
+                <v-col cols="12" sm="6">
+                  <SettingsNote />
+                </v-col>
+                <v-col cols="12" sm="6"">
+                  <SettingsTheme />
+                </v-col>
+
               </v-row>
             </v-card-text>
           </v-card>
         </v-col>
 
         <!-- Board options -->
-        <v-col cols="4">
+        <v-col cols="12">
           <SettingsBoard />
         </v-col>
       </v-row>

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -10,22 +10,22 @@
         <!-- Other options -->
         <v-col cols="12">
           <v-card class="elevation-12">
-            <v-toolbar color="primary" flat>
+            <v-toolbar flat>
               <v-toolbar-title>{{$t('settings.others.title')}}</v-toolbar-title>
               <div class="flex-grow-1"></div>
             </v-toolbar>
             <v-card-text class="pb-0">
               <v-row>
-                <v-col cols="12" >
+                <v-col cols="4" >
                   <SettingsNote />
                 </v-col>
-                <v-col cols="12" sm="6">
+                <v-col cols="4" sm="4">
                   <SettingsTheme />
                 </v-col>
-                <v-col cols="12" sm="6">
+                <v-col cols="4" sm="4">
                   <SettingsLanguage />
                 </v-col>
-                <v-col cols="12" >
+                <v-col cols="4" >
                   <SettingsDateTime />
                 </v-col>
               </v-row>
@@ -34,7 +34,7 @@
         </v-col>
 
         <!-- Board options -->
-        <v-col cols="12">
+        <v-col cols="4">
           <SettingsBoard />
         </v-col>
       </v-row>

--- a/pages/trash/index.vue
+++ b/pages/trash/index.vue
@@ -86,17 +86,16 @@
 
     <v-footer app class="pa-0">
       <v-toolbar dense color="footer">
-        <v-toolbar-items>
-          <v-btn @click="onDeleteAllRequest" color="error">
-            <v-icon >delete_forever</v-icon>
-            {{$t('note.delete.all.action')}}
-          </v-btn>
-        </v-toolbar-items>
+
         <div class="flex-grow-1"></div>
 
         <v-toolbar-items>
           <v-btn @click="showTags = !showTags">
             <v-icon :color="showTags ? 'primary' : ''">flag</v-icon>
+          </v-btn>
+          <v-btn @click="onDeleteAllRequest" color="error">
+            <v-icon >delete_forever</v-icon>
+            {{$t('note.delete.all.action')}}
           </v-btn>
         </v-toolbar-items>
       </v-toolbar>


### PR DESCRIPTION
Dev Notes


Was hab ich geändert:

* Readme korrigiert bis auf generate. npm run generate ging auch nicht
* Das Theme wieder auf Default gesetzt. Alles andere sieht kacke aus.
* Klick auf „Note hinzufügen“ zeigt direkt die Textnote an. Dort lässt sich dann auf anderen Typ wechseln. (Muss noch zu Ende programmiert werden mit Abschlusseite richtig)
* Falls dir das jetzt 1 Klick zuviel ist: Fast Mode / Expert Mode bei dem du deine alte Auswahl wieder hast. Auf Desktop würd ich dann auch direkt alle Typen im Menü anzeigen, dann sparst nochmal einen Klick ….
* Man könnte auch im Clipboard nachschauen was man da gerade drin hat. Wenn eine Bild URL, nehme diese Typ. Fänd ich ganz geil
* Einstieg einfacher für Anfänger
* Hilfetext kurz und "different types" nur einblenden wenn nötig
* Knöpfe wie Tags/Filterung ausblenden bis sie Sinn ergeben
Menü
* Anzahl der Notes für Alle bzw. Pro Dashboard hinten drangeschrieben in Klammern (muss noch gefixt werden für Dashboards)
* Die Menüs besser abgetrennt und die Dashboards einfach ein bisschen eingerückt
* Papierkorb nur einblenden wenn was drin ist
* Paar kleine Texte angepasst (auf englisch)
* Primary Masse raus bei Backup/Settings. Generell gilt. Nur 1 Primary Element pro Page. Wenn mehr, begründen und nur in Ausnahmefällen (Lenkt zu sehr ab)
* Settings bisschen komprimiert
* Backup ausklappbar
* Hier könnte man noch die benutzen direkt ausklappen
* Notes schneiden jetzt Text ab wenn dieser zu groß ist und alles sprengt (ausser im Fullscreen Modus)
* Aktionen pro Seite immer komplett nach rechts geschoben. Die Zweiteilung war mir zu willkürlich. Alternativ könnte man auch immer EINE Primary Aktion nach rechts und den rest nach links.
Umtitled Überschriften weg

TODOS

* Deutsche Sprache anpassen
* Wieso kann ich keine Bilder lokal lokal hochladen bei Picture? Camera geht ja auch
* Schön wäre noch wenn man das Template Note noch etwas optisch abhebt vom Text Note
* "Anzahl der Notes von einem Dashboard" sind nicht im Store. Berechnung sah mir in der View kompliziert aus. Daher ging nicht die „wichtige“ Anzeige der Anzahl im Menü. 
* Für jeden Tag den man anlegt könnte man auch ein Dashboard automatisch anlegen. Jedenfalls war das bei meinen Fällen immer so. Was denkst du?
* Knöpfe könnten noch nen Tooltip bekommen, damit man weiss was dahinter steckt. Icons sind nicht immer eindeutig
* Beim Anlegen eines Tags direkt Fokus auf das Inputfeld.
Darstellung 
* Beim Sortieren wenn „untilted“ Überschrift nicht diese anzeigen, sondern den Beginn des Contents